### PR TITLE
Implements Webhook Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A robust Go application for PostgreSQL backups and restores with strict error ha
 - **Rsync file transfer** - Fast, efficient transfer with resume capability
 - **S3-compatible storage** - Upload/download backups to/from Garage or any S3-compatible storage
 - **Automatic retention management** - Keep only the N most recent backups
-- **Email notifications** - Success/failure notifications via go-notification for both backup and restore
+- **Webhook notifications** - Success/failure notifications via HTTP POST webhooks with JSON payload for both backup and restore
 - **Progress tracking** - Real-time progress for all long-running operations
 - **Structured logging** - Clear, parseable logs with context
 - **Graceful shutdown** - Handles SIGINT/SIGTERM with cleanup
@@ -104,9 +104,9 @@ restore:
 
 notification:
   enabled: true
-  api_key: "your-api-key"
-  from: "notifications@example.com"
-  to: "admin@example.com"
+  webhook_url: "https://webhook.example.com/notifications"
+  headers:
+    Authorization: "Bearer your-token-here"
 ```
 
 ## Usage
@@ -476,7 +476,156 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 - rsync installed on local machine
 - S3-compatible storage (Garage, MinIO, AWS S3, etc.)
 - sshpass (optional, for password authentication with rsync)
-- [go-notification](https://github.com/hra42/go-notification) binary (optional, for email notifications)
+
+## Webhook Notifications
+
+pg_backup supports webhook notifications for all backup and restore operations. Notifications are sent as HTTP POST requests with JSON payloads, providing flexibility to integrate with any notification system (Slack, Discord, Microsoft Teams, custom monitoring systems, etc.).
+
+### Configuration
+
+Configure webhook notifications in your `config.yaml`:
+
+```yaml
+notification:
+  enabled: true
+  webhook_url: "https://webhook.example.com/notifications"
+  headers:
+    Authorization: "Bearer your-secret-token"
+    X-Custom-Header: "custom-value"
+```
+
+### Payload Format
+
+All webhooks send a JSON payload with the following structure:
+
+```json
+{
+  "event_type": "backup_success",
+  "database": "production_db",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "duration": "5m23s",
+  "duration_ms": 323000,
+  "backup_size": 1073741824,
+  "hostname": "backup-server",
+  "version": "1.0.0"
+}
+```
+
+### Event Types
+
+#### backup_success
+Sent when a backup completes successfully.
+
+**Fields:**
+- `event_type`: `"backup_success"`
+- `database`: Database name
+- `timestamp`: ISO 8601 timestamp
+- `duration`: Human-readable duration (e.g., "5m23s")
+- `duration_ms`: Duration in milliseconds
+- `backup_size`: Backup file size in bytes
+- `hostname`: Server hostname where backup ran
+- `version`: pg_backup version
+
+#### backup_failure
+Sent when a backup fails.
+
+**Fields:**
+- `event_type`: `"backup_failure"`
+- `database`: Database name
+- `timestamp`: ISO 8601 timestamp
+- `error`: Error message
+- `stage`: Failed stage (SSH Connection, Remote Backup Creation, File Transfer, S3 Upload, Cleanup)
+- `hostname`: Server hostname
+- `version`: pg_backup version
+
+#### restore_success
+Sent when a restore completes successfully.
+
+**Fields:**
+- `event_type`: `"restore_success"`
+- `database`: Target database name
+- `timestamp`: ISO 8601 timestamp
+- `duration`: Human-readable duration
+- `duration_ms`: Duration in milliseconds
+- `backup_key`: S3 key of the restored backup
+- `hostname`: Server hostname
+- `version`: pg_backup version
+
+#### restore_failure
+Sent when a restore fails.
+
+**Fields:**
+- `event_type`: `"restore_failure"`
+- `database`: Target database name
+- `timestamp`: ISO 8601 timestamp
+- `error`: Error message
+- `stage`: Failed stage
+- `hostname`: Server hostname
+- `version`: pg_backup version
+
+### Integration Examples
+
+#### Slack Incoming Webhook
+```yaml
+notification:
+  enabled: true
+  webhook_url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+```
+
+You'll need a webhook transformer service to convert the JSON payload to Slack's format, or use a service like Zapier/Make.
+
+#### Discord Webhook
+```yaml
+notification:
+  enabled: true
+  webhook_url: "https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+```
+
+Discord requires a specific JSON format, so you may need a transformation service.
+
+#### Custom Webhook Server
+You can create a simple webhook receiver that processes the notifications:
+
+```go
+// Example webhook receiver
+http.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
+    var payload map[string]interface{}
+    json.NewDecoder(r.Body).Decode(&payload)
+
+    eventType := payload["event_type"].(string)
+    database := payload["database"].(string)
+
+    // Process notification based on event type
+    switch eventType {
+    case "backup_success":
+        log.Printf("Backup succeeded for %s", database)
+    case "backup_failure":
+        log.Printf("Backup failed for %s: %s", database, payload["error"])
+    }
+
+    w.WriteHeader(http.StatusOK)
+})
+```
+
+#### HTTP Authentication
+Use custom headers for authentication:
+
+```yaml
+notification:
+  enabled: true
+  webhook_url: "https://api.example.com/webhooks"
+  headers:
+    Authorization: "Bearer your-secret-token"
+    X-API-Key: "your-api-key"
+```
+
+### Webhook Behavior
+
+- **Timeout**: Webhook requests timeout after 30 seconds
+- **Retry**: No automatic retries (failures are logged but don't affect backup/restore operations)
+- **Non-blocking**: Webhook failures don't cause backup/restore operations to fail
+- **User-Agent**: All requests include `User-Agent: pg_backup/VERSION`
+- **Content-Type**: Always `application/json`
 
 ## Security Notes
 
@@ -484,3 +633,5 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 - Use SSH key authentication when possible
 - Consider using environment variables for sensitive values
 - Never commit configuration files with credentials to version control
+- Use HTTPS for webhook URLs to ensure notification data is encrypted in transit
+- Protect webhook authentication tokens as they provide access to notification endpoints

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -108,15 +108,15 @@ restore:
   #   expression: "Sunday 03:00"  # Weekly restore test on Sunday at 3 AM
   #   run_on_start: false
 
-# Email notification settings (optional)
-# Requires: https://github.com/hra42/go-notification
+# Webhook notification settings (optional)
+# Sends HTTP POST requests with JSON payload to the configured webhook URL
 notification:
   enabled: false                                           # Enable/disable notifications
-  binary_path: "/usr/local/bin/go-notification"          # Path to notification binary
-  api_key: "re_example"                                 # API key for notification service (example, see docs of the notification service)
-  from: "notifications@example.com"                    # From email address
-  to: "hra42@example.com"                                  # To email address
-  reply_to: "example@example.com"               # Reply-to address (optional)
+  webhook_url: "https://webhook.example.com/notifications" # Webhook URL to send notifications
+  # Optional custom headers (e.g., for authentication)
+  headers:
+    Authorization: "Bearer your-token-here"
+    X-Custom-Header: "custom-value"
 
 # Log configuration (optional)
 # Controls where and how logs are written

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,12 +80,9 @@ type RestoreConfig struct {
 }
 
 type NotificationConfig struct {
-	Enabled     bool   `yaml:"enabled"`
-	BinaryPath  string `yaml:"binary_path"`
-	APIKey      string `yaml:"api_key"`
-	From        string `yaml:"from"`
-	To          string `yaml:"to"`
-	ReplyTo     string `yaml:"reply_to"`
+	Enabled    bool              `yaml:"enabled"`
+	WebhookURL string            `yaml:"webhook_url"`
+	Headers    map[string]string `yaml:"headers,omitempty"`
 }
 
 type LogConfig struct {
@@ -134,8 +131,7 @@ func LoadConfig(path string) (*Config, error) {
 			Jobs:         1,
 		},
 		Notification: NotificationConfig{
-			Enabled:    false,
-			BinaryPath: "/usr/local/bin/go-notification",
+			Enabled: false,
 		},
 		Log: LogConfig{
 			FilePath:       "", // Empty means stdout
@@ -268,17 +264,8 @@ func (c *Config) Validate() error {
 
 	// Validate notification config if enabled
 	if c.Notification.Enabled {
-		if c.Notification.BinaryPath == "" {
-			c.Notification.BinaryPath = "/usr/local/bin/go-notification"
-		}
-		if c.Notification.APIKey == "" {
-			return fmt.Errorf("notification API key is required when notifications are enabled")
-		}
-		if c.Notification.From == "" {
-			return fmt.Errorf("notification from address is required when notifications are enabled")
-		}
-		if c.Notification.To == "" {
-			return fmt.Errorf("notification to address is required when notifications are enabled")
+		if c.Notification.WebhookURL == "" {
+			return fmt.Errorf("notification webhook URL is required when notifications are enabled")
 		}
 	}
 

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -1,25 +1,56 @@
 package notification
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
-	"strings"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/hra42/pg_backup/internal/config"
 )
 
+// EventType represents the type of notification event
+type EventType string
+
+const (
+	EventBackupSuccess  EventType = "backup_success"
+	EventBackupFailure  EventType = "backup_failure"
+	EventRestoreSuccess EventType = "restore_success"
+	EventRestoreFailure EventType = "restore_failure"
+)
+
+// NotificationPayload represents the JSON payload sent to the webhook
+type NotificationPayload struct {
+	EventType    EventType `json:"event_type"`
+	Database     string    `json:"database"`
+	Timestamp    string    `json:"timestamp"`
+	Duration     *string   `json:"duration,omitempty"`     // Duration in human-readable format (for success events)
+	DurationMs   *int64    `json:"duration_ms,omitempty"`  // Duration in milliseconds (for success events)
+	BackupSize   *int64    `json:"backup_size,omitempty"`  // Backup size in bytes (for backup success)
+	BackupKey    *string   `json:"backup_key,omitempty"`   // Backup key/identifier (for restore events)
+	Error        *string   `json:"error,omitempty"`        // Error message (for failure events)
+	Stage        *string   `json:"stage,omitempty"`        // Failed stage (for failure events)
+	Hostname     string    `json:"hostname,omitempty"`     // Hostname where the backup/restore ran
+	Version      string    `json:"version,omitempty"`      // Application version
+}
+
 type NotificationClient struct {
-	config *config.NotificationConfig
-	logger *slog.Logger
+	config     *config.NotificationConfig
+	logger     *slog.Logger
+	httpClient *http.Client
 }
 
 func NewNotificationClient(cfg *config.NotificationConfig, logger *slog.Logger) *NotificationClient {
 	return &NotificationClient{
 		config: cfg,
 		logger: logger,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
 	}
 }
 
@@ -28,24 +59,21 @@ func (n *NotificationClient) SendBackupSuccess(database string, duration time.Du
 		return nil
 	}
 
-	subject := fmt.Sprintf("✓ Backup Successful: %s", database)
-	
-	// Format backup size
-	sizeStr := formatBytes(backupSize)
-	
-	text := fmt.Sprintf(
-		"PostgreSQL backup completed successfully.\n\n"+
-			"Database: %s\n"+
-			"Duration: %s\n"+
-			"Backup Size: %s\n"+
-			"Timestamp: %s\n",
-		database,
-		duration.Round(time.Second),
-		sizeStr,
-		time.Now().UTC().Format(time.RFC3339),
-	)
+	durationStr := duration.Round(time.Second).String()
+	durationMs := duration.Milliseconds()
 
-	return n.sendNotification(subject, text)
+	payload := NotificationPayload{
+		EventType:  EventBackupSuccess,
+		Database:   database,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Duration:   &durationStr,
+		DurationMs: &durationMs,
+		BackupSize: &backupSize,
+		Hostname:   getHostname(),
+		Version:    getVersion(),
+	}
+
+	return n.sendWebhook(payload)
 }
 
 func (n *NotificationClient) SendBackupFailure(database string, err error, stage string) error {
@@ -53,70 +81,84 @@ func (n *NotificationClient) SendBackupFailure(database string, err error, stage
 		return nil
 	}
 
-	subject := fmt.Sprintf("✗ Backup Failed: %s", database)
-	
-	text := fmt.Sprintf(
-		"PostgreSQL backup failed.\n\n"+
-			"Database: %s\n"+
-			"Failed Stage: %s\n"+
-			"Error: %s\n"+
-			"Timestamp: %s\n",
-		database,
-		stage,
-		err.Error(),
-		time.Now().UTC().Format(time.RFC3339),
-	)
+	errMsg := err.Error()
 
-	return n.sendNotification(subject, text)
+	payload := NotificationPayload{
+		EventType: EventBackupFailure,
+		Database:  database,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Error:     &errMsg,
+		Stage:     &stage,
+		Hostname:  getHostname(),
+		Version:   getVersion(),
+	}
+
+	return n.sendWebhook(payload)
 }
 
-func (n *NotificationClient) sendNotification(subject, text string) error {
-	args := []string{
-		"-api-key", n.config.APIKey,
-		"-from", n.config.From,
-		"-to", n.config.To,
-		"-subject", subject,
-		"-text", text,
+func (n *NotificationClient) sendWebhook(payload NotificationPayload) error {
+	if n.config.WebhookURL == "" {
+		n.logger.Warn("Webhook URL not configured, skipping notification")
+		return nil
 	}
 
-	if n.config.ReplyTo != "" {
-		args = append(args, "-reply-to", n.config.ReplyTo)
+	// Marshal payload to JSON
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		n.logger.Error("Failed to marshal notification payload",
+			slog.String("error", err.Error()))
+		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
+	// Create HTTP request
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, n.config.BinaryPath, args...)
-	
-	n.logger.Debug("Sending notification",
-		slog.String("subject", subject),
-		slog.String("to", n.config.To))
-
-	output, err := cmd.CombinedOutput()
+	req, err := http.NewRequestWithContext(ctx, "POST", n.config.WebhookURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		n.logger.Error("Failed to send notification",
+		n.logger.Error("Failed to create webhook request",
+			slog.String("error", err.Error()))
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("pg_backup/%s", getVersion()))
+
+	// Add custom headers from config
+	for key, value := range n.config.Headers {
+		req.Header.Set(key, value)
+	}
+
+	n.logger.Debug("Sending webhook notification",
+		slog.String("url", n.config.WebhookURL),
+		slog.String("event_type", string(payload.EventType)),
+		slog.String("database", payload.Database))
+
+	// Send request
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		n.logger.Error("Failed to send webhook notification",
 			slog.String("error", err.Error()),
-			slog.String("output", string(output)))
-		return fmt.Errorf("notification failed: %w", err)
+			slog.String("url", n.config.WebhookURL))
+		return fmt.Errorf("webhook request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		n.logger.Error("Webhook returned error status",
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("status", resp.Status),
+			slog.String("url", n.config.WebhookURL))
+		return fmt.Errorf("webhook returned status %d: %s", resp.StatusCode, resp.Status)
 	}
 
-	n.logger.Info("Notification sent successfully",
-		slog.String("subject", subject))
-	
+	n.logger.Info("Webhook notification sent successfully",
+		slog.String("event_type", string(payload.EventType)),
+		slog.Int("status_code", resp.StatusCode))
+
 	return nil
-}
-
-func formatBytes(bytes int64) string {
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
 
 func (n *NotificationClient) SendRestoreSuccess(database string, duration time.Duration, backupKey string) error {
@@ -124,21 +166,21 @@ func (n *NotificationClient) SendRestoreSuccess(database string, duration time.D
 		return nil
 	}
 
-	subject := fmt.Sprintf("✓ Restore Successful: %s", database)
-	
-	text := fmt.Sprintf(
-		"PostgreSQL restore completed successfully.\n\n"+
-			"Database: %s\n"+
-			"Backup Used: %s\n"+
-			"Duration: %s\n"+
-			"Timestamp: %s\n",
-		database,
-		backupKey,
-		duration.Round(time.Second),
-		time.Now().UTC().Format(time.RFC3339),
-	)
+	durationStr := duration.Round(time.Second).String()
+	durationMs := duration.Milliseconds()
 
-	return n.sendNotification(subject, text)
+	payload := NotificationPayload{
+		EventType:  EventRestoreSuccess,
+		Database:   database,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Duration:   &durationStr,
+		DurationMs: &durationMs,
+		BackupKey:  &backupKey,
+		Hostname:   getHostname(),
+		Version:    getVersion(),
+	}
+
+	return n.sendWebhook(payload)
 }
 
 func (n *NotificationClient) SendRestoreFailure(database string, err error, stage string) error {
@@ -146,39 +188,88 @@ func (n *NotificationClient) SendRestoreFailure(database string, err error, stag
 		return nil
 	}
 
-	subject := fmt.Sprintf("✗ Restore Failed: %s", database)
-	
-	text := fmt.Sprintf(
-		"PostgreSQL restore failed.\n\n"+
-			"Database: %s\n"+
-			"Failed Stage: %s\n"+
-			"Error: %s\n"+
-			"Timestamp: %s\n",
-		database,
-		stage,
-		err.Error(),
-		time.Now().UTC().Format(time.RFC3339),
-	)
+	errMsg := err.Error()
 
-	return n.sendNotification(subject, text)
+	payload := NotificationPayload{
+		EventType: EventRestoreFailure,
+		Database:  database,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Error:     &errMsg,
+		Stage:     &stage,
+		Hostname:  getHostname(),
+		Version:   getVersion(),
+	}
+
+	return n.sendWebhook(payload)
 }
 
+// GetBackupStage determines the stage of backup failure from error message
 func GetBackupStage(err error) string {
 	errStr := err.Error()
-	if strings.Contains(errStr, "exit code 2") || strings.Contains(errStr, "SSH") {
-		return "SSH Connection"
+	if len(errStr) == 0 {
+		return "Unknown"
 	}
-	if strings.Contains(errStr, "exit code 3") || strings.Contains(errStr, "backup creation") {
-		return "Remote Backup Creation"
+
+	// Check for specific error patterns
+	patterns := map[string]string{
+		"exit code 2": "SSH Connection",
+		"SSH":         "SSH Connection",
+		"exit code 3": "Remote Backup Creation",
+		"backup creation": "Remote Backup Creation",
+		"exit code 4": "File Transfer",
+		"transfer":    "File Transfer",
+		"exit code 5": "S3 Upload",
+		"S3":          "S3 Upload",
+		"cleanup":     "Cleanup",
 	}
-	if strings.Contains(errStr, "exit code 4") || strings.Contains(errStr, "transfer") {
-		return "File Transfer"
+
+	for pattern, stage := range patterns {
+		if containsIgnoreCase(errStr, pattern) {
+			return stage
+		}
 	}
-	if strings.Contains(errStr, "exit code 5") || strings.Contains(errStr, "S3") {
-		return "S3 Upload"
-	}
-	if strings.Contains(errStr, "cleanup") {
-		return "Cleanup"
-	}
+
 	return "Unknown"
+}
+
+// Helper functions
+func getHostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
+}
+
+func getVersion() string {
+	// This should match the version in main.go
+	// For now, return a placeholder - this can be set via build flags
+	return "1.0.0"
+}
+
+func containsIgnoreCase(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(contains(s, substr) || contains(toLower(s), toLower(substr)))
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func toLower(s string) string {
+	result := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			result[i] = c + ('a' - 'A')
+		} else {
+			result[i] = c
+		}
+	}
+	return string(result)
 }


### PR DESCRIPTION
Replaces the prior email-based notification system, which relied on an external binary, with a flexible webhook-based approach. Notifications are now sent as HTTP POST requests with a structured JSON payload, enabling easier integration with various monitoring and alerting tools.

*   **Configuration**: Updates the `notification` section to include a `webhook_url` and optional custom `headers` for authentication or additional context.
*   **Core Logic**: Refactors the internal notification client to directly send HTTP POST requests, eliminating the dependency on an external `go-notification` binary.
*   **Payloads**: Introduces standardized JSON payloads for `backup_success`, `backup_failure`, `restore_success`, and `restore_failure` events. Payloads include comprehensive details such as duration, backup size, error messages, failed stages, hostname, and application version.
*   **Documentation**: Adds a dedicated "Webhook Notifications" section to the `README.md`, detailing configuration, payload format, event types, and integration examples for common services like Slack and Discord.